### PR TITLE
Pre-release update for 1.0

### DIFF
--- a/ConnectingView_Patch.cs
+++ b/ConnectingView_Patch.cs
@@ -9,18 +9,21 @@ namespace RemoveVignette;
 internal static class ConnectingView_Patch
 {
     [HarmonyPostfix]
-    [HarmonyPatch(typeof(ConnectingView), nameof(ConnectingView.BackgroundButton_OnClick))]
-    private static void BackgroundButton_OnClick()
+    [HarmonyPatch(typeof(ConnectingView), nameof(ConnectingView.Update))]
+    private static void Update(ConnectingView __instance)
     {
-        var postProcess = GameObject.Find("Scene PostProcess");
-        var volume = postProcess.GetComponent<Volume>();
-
-        foreach (var vc in volume.profile.components)
+        if (__instance._Ready)
         {
-            if (vc.name.StartsWith("Vignette"))
+            var postProcess = GameObject.Find("Scene PostProcess");
+            var volume = postProcess.GetComponent<Volume>();
+
+            foreach (var vc in volume.profile.components)
             {
-                vc.active = false;
-                break;
+                if (vc.name.StartsWith("Vignette"))
+                {
+                    vc.active = false;
+                    break;
+                }
             }
         }
     }

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 Removes Vignette
 
 ### Installation
-- Install [BepInEx](https://github.com/Odjit/BepInEx/releases/tag/vrising-release)
+- Install [BepInEx](https://github.com/decaprime/VRising-Modding/releases/tag/1.690.2)
 - Extract _RemoveVignette.dll_ into _(VRising folder)/BepInEx/plugins_
 
 ### Support
@@ -11,10 +11,13 @@ Join the [modding discord](https://vrisingmods.com/discord) for support and tag 
 Submit a ticket on [GitHub](https://github.com/iZastic/vrising-removevignette/issues)
 
 ### Changelog
-`1.2.0`
-- Updated for 1.0 release
+`1.2.1`
+- Updated for 1.0 RC2 release
 
 <details>
+
+`1.2.0`
+- Updated for 1.0 release
 
 `1.1.0`
 - Updated for Gloomrot

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 Removes Vignette
 
 ### Installation
-- Install [BepInEx](https://v-rising.thunderstore.io/package/BepInEx/BepInExPack_V_Rising/)
+- Install [BepInEx](https://github.com/Odjit/BepInEx/releases/tag/vrising-release)
 - Extract _RemoveVignette.dll_ into _(VRising folder)/BepInEx/plugins_
 
 ### Support
@@ -11,10 +11,13 @@ Join the [modding discord](https://vrisingmods.com/discord) for support and tag 
 Submit a ticket on [GitHub](https://github.com/iZastic/vrising-removevignette/issues)
 
 ### Changelog
-`1.1.0`
-- Updated for Gloomrot
+`1.2.0`
+- Updated for 1.0 release
 
 <details>
+
+`1.1.0`
+- Updated for Gloomrot
 
 `1.0.0`
 - Initial upload

--- a/RemoveVignette.csproj
+++ b/RemoveVignette.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net6.0</TargetFramework>
     <AssemblyName>RemoveVignette</AssemblyName>
     <Description>Removes Vignette</Description>
-    <Version>1.1.0</Version>
+    <Version>1.2.0</Version>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <LangVersion>latest</LangVersion>
     <Authors>iZastic</Authors>
@@ -14,7 +14,7 @@
   </PropertyGroup>
   
   <ItemGroup>
-    <PackageReference Include="VRising.Unhollowed.Client" Version="0.6.5.57575090" />
+    <PackageReference Include="VRising.Unhollowed.Client" Version="1.0.0.*" />
     <PackageReference Include="BepInEx.Unity.IL2CPP" Version="6.0.0-be.*" IncludeAssets="compile" />
   </ItemGroup>
 

--- a/RemoveVignette.csproj
+++ b/RemoveVignette.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net6.0</TargetFramework>
     <AssemblyName>RemoveVignette</AssemblyName>
     <Description>Removes Vignette</Description>
-    <Version>1.2.0</Version>
+    <Version>1.2.1</Version>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <LangVersion>latest</LangVersion>
     <Authors>iZastic</Authors>
@@ -14,7 +14,7 @@
   </PropertyGroup>
   
   <ItemGroup>
-    <PackageReference Include="VRising.Unhollowed.Client" Version="1.0.0.*" />
+    <PackageReference Include="VRising.Unhollowed.Client" Version="1.0.*" />
     <PackageReference Include="BepInEx.Unity.IL2CPP" Version="6.0.0-be.*" IncludeAssets="compile" />
   </ItemGroup>
 


### PR DESCRIPTION
- Updated `VRising.Unhollowed.Client` to 1.0.0.*

- "Temporary" fix for `ConnectingView.BackgroundButton_OnClick` to use `ConnectingView.Update` due to error:
```
[Error  :Il2CppInterop] During invoking native->managed trampoline Exception: System.
NullReferenceException: Object reference not set to an instance of an object.
   at RemoveVignette.ConnectingView_Patch.BackgroundButton_OnClick()
   at DMD<ProjectM.UI.ConnectingView::BackgroundButton_OnClick>(ConnectingView this)
   at (il2cpp -> managed) BackgroundButton_OnClick(IntPtr , Il2CppMethodInfo* )
```
- I am uncertain if changes involving `ConnectingView.Update` are computationally expensive and hope iZastic finds a better method, if needed. Though I experienced no immediate issues during testing.